### PR TITLE
Added request command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Go template
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.idea
+nats
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.6-onbuild
+
+ENTRYPOINT ["app"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # nats cli
 Go Application that combines nats sub and pub
 
-#Download
+# Download
 ```
 go get github.com/starkandwayne/nats
 ```
 
-#Actions
+# Actions
 
 ## Pub 
 Publish a message on a subject
@@ -18,7 +18,7 @@ Subscribe to a subject and await messages
 Publish a message and await reply
 
 
-#Usage
+# Usage
 ```
   nats pub [-s server] [--ssl]  <subject> <msg> 
       or

--- a/README.md
+++ b/README.md
@@ -6,9 +6,23 @@ Go Application that combines nats sub and pub
 go get github.com/starkandwayne/nats
 ```
 
-Usage
+#Actions
+
+## Pub 
+Publish a message on a subject
+
+## Sub
+Subscribe to a subject and await messages
+
+## Request
+Publish a message and await reply
+
+
+#Usage
 ```
   nats pub [-s server] [--ssl]  <subject> <msg> 
       or
   nats sub [-s server] [--ssl] [-t] [-r] <subject> 
+      or
+  nats req [-s server] [--ssl] [-t] [-r] [-w] <subject> <msg>
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Go Application that combines nats sub and pub
 
 #Download
 ```
-go get github.com/soutenniza/nats
+go get github.com/starkandwayne/nats
 ```
 
 Usage

--- a/nats.go
+++ b/nats.go
@@ -154,7 +154,7 @@ func main(){
       Action: func(c *cli.Context){
         var urls = c.String("s")
         var ssl = c.Bool("ssl")
-        var timeout = c.Duration("timeout")
+        var timeout = c.Duration("w")
         var showtime = c.Bool("t")
         var rawoutput = c.Bool("r")
 

--- a/nats.go
+++ b/nats.go
@@ -41,8 +41,9 @@ func main(){
   app.Name = "nats"
   app.Usage = "Nats Pub and Sub - Go Client"
   app.Version = "1.0.2"
-  app.Action = func(c *cli.Context) {
+  app.Action = func(c *cli.Context) error {
     cli.ShowAppHelp(c)
+    return nil
   }
   app.Commands = []cli.Command{
     {

--- a/nats.go
+++ b/nats.go
@@ -15,7 +15,7 @@ import(
   var message = "Usage: nats sub or nats pub"
   var subMessage = "Usage: nats sub [-s server url] [--ssl] [-t] <subject> \n"
   var pubMessage = "Usage: nats pub [-s server url] [--ssl] [-t] <subject> <msg> \n"
-  var reqMessage = "Usage: nats req [-s server url] [--ssl] [-t] <subject> <msg> \n"
+  var reqMessage = "Usage: nats req [-s server url] [--ssl] [-t] [-w] <subject> <msg> \n"
   var index = 0
 
 func usage() {
@@ -45,50 +45,6 @@ func main(){
     cli.ShowAppHelp(c)
   }
   app.Commands = []cli.Command{
-    {
-      Name:       "req",
-      ShortName:  "r",
-      Usage:      reqMessage,
-      Flags:  []cli.Flag{
-        cli.StringFlag{Name:   "s", Value:  nats.DefaultURL, Usage: "The nats server URLs (separated by comma).\n\tServer Url must be in following format: nats://nats_user:nats_password@host:port or nats://host:port"},
-        cli.BoolFlag{Name:   "ssl", Usage:  "Use Secure Connection"},
-        cli.DurationFlag{Name: "timeout", Value: 2 * time.Second, Usage: "Duration to wait for response, eg '1s'"},
-      },
-      Action: func(c *cli.Context){
-        var urls = c.String("s")
-        var ssl = c.Bool("ssl")
-        var timeout = c.Duration("timeout")
-
-        args := c.Args()
-        if len(args) < 1 {
-          cli.ShowAppHelp(c)
-          os.Exit(1)
-        }
-
-        opts := nats.DefaultOptions
-        opts.Servers = strings.Split(urls, ",")
-        for i, s := range opts.Servers {
-          opts.Servers[i] = strings.Trim(s, " ")
-        }
-
-        opts.Secure = ssl
-
-        nc, err := opts.Connect()
-        if err != nil {
-          log.Fatalf("Can't connect: %v\n", err)
-        }
-
-        subj, msg := args[0], []byte(args[1])
-
-        resp, err := nc.Request(subj, msg, timeout)
-        if err != nil {
-          log.Fatal("Error during request:", err)
-        }
-        fmt.Printf("Published [%s] : '%s'\n", subj, msg)
-        printMsg(resp, 1)
-        nc.Close()
-      },
-    },
     {
       Name:       "pub",
       ShortName:  "p",
@@ -182,6 +138,64 @@ func main(){
           fmt.Printf("Listening on [%s]\n", subj)
         }
         runtime.Goexit()
+      },
+    },
+    {
+      Name:       "req",
+      ShortName:  "r",
+      Usage:      reqMessage,
+      Flags:  []cli.Flag{
+        cli.StringFlag{Name:   "s", Value:  nats.DefaultURL, Usage: "The nats server URLs (separated by comma).\n\tServer Url must be in following format: nats://nats_user:nats_password@host:port or nats://host:port"},
+        cli.BoolFlag{Name:   "ssl", Usage:  "Use Secure Connection"},
+        cli.DurationFlag{Name: "w", Value: 2 * time.Second, Usage: "Duration to wait for response, eg '1s'"},
+        cli.BoolFlag{Name:   "t",Usage:  "Display timestamps"},
+        cli.BoolFlag{Name:   "r",Usage:  "Display raw output"},
+      },
+      Action: func(c *cli.Context){
+        var urls = c.String("s")
+        var ssl = c.Bool("ssl")
+        var timeout = c.Duration("timeout")
+        var showtime = c.Bool("t")
+        var rawoutput = c.Bool("r")
+
+        args := c.Args()
+        if len(args) < 1 {
+          cli.ShowAppHelp(c)
+          os.Exit(1)
+        }
+
+        opts := nats.DefaultOptions
+        opts.Servers = strings.Split(urls, ",")
+        for i, s := range opts.Servers {
+          opts.Servers[i] = strings.Trim(s, " ")
+        }
+
+        opts.Secure = ssl
+
+        nc, err := opts.Connect()
+        if err != nil {
+          log.Fatalf("Can't connect: %v\n", err)
+        }
+
+        subj, msg := args[0], []byte(args[1])
+
+        resp, err := nc.Request(subj, msg, timeout)
+        if err != nil {
+          log.Fatal("Error during request:", err)
+        }
+        fmt.Printf("Published [%s] : '%s'\n", subj, msg)
+
+        if(rawoutput){
+          printRaw(resp)
+        }else{
+          if(showtime){
+            printTimeMsg(resp, 1)
+          }else{
+            printMsg(resp, 1)
+          }
+        }
+
+        nc.Close()
       },
     },
   }

--- a/nats.go
+++ b/nats.go
@@ -7,13 +7,15 @@ import(
   "strings"
   "runtime"
 
-  "github.com/apcera/nats"
+  "github.com/nats-io/nats"
   "github.com/codegangsta/cli"
-  )
+  "time"
+)
 
   var message = "Usage: nats sub or nats pub"
   var subMessage = "Usage: nats sub [-s server url] [--ssl] [-t] <subject> \n"
   var pubMessage = "Usage: nats pub [-s server url] [--ssl] [-t] <subject> <msg> \n"
+  var reqMessage = "Usage: nats req [-s server url] [--ssl] [-t] <subject> <msg> \n"
   var index = 0
 
 func usage() {
@@ -43,6 +45,50 @@ func main(){
     cli.ShowAppHelp(c)
   }
   app.Commands = []cli.Command{
+    {
+      Name:       "req",
+      ShortName:  "r",
+      Usage:      reqMessage,
+      Flags:  []cli.Flag{
+        cli.StringFlag{Name:   "s", Value:  nats.DefaultURL, Usage: "The nats server URLs (separated by comma).\n\tServer Url must be in following format: nats://nats_user:nats_password@host:port or nats://host:port"},
+        cli.BoolFlag{Name:   "ssl", Usage:  "Use Secure Connection"},
+        cli.DurationFlag{Name: "timeout", Value: 2 * time.Second, Usage: "Duration to wait for response, eg '1s'"},
+      },
+      Action: func(c *cli.Context){
+        var urls = c.String("s")
+        var ssl = c.Bool("ssl")
+        var timeout = c.Duration("timeout")
+
+        args := c.Args()
+        if len(args) < 1 {
+          cli.ShowAppHelp(c)
+          os.Exit(1)
+        }
+
+        opts := nats.DefaultOptions
+        opts.Servers = strings.Split(urls, ",")
+        for i, s := range opts.Servers {
+          opts.Servers[i] = strings.Trim(s, " ")
+        }
+
+        opts.Secure = ssl
+
+        nc, err := opts.Connect()
+        if err != nil {
+          log.Fatalf("Can't connect: %v\n", err)
+        }
+
+        subj, msg := args[0], []byte(args[1])
+
+        resp, err := nc.Request(subj, msg, timeout)
+        if err != nil {
+          log.Fatal("Error during request:", err)
+        }
+        fmt.Printf("Published [%s] : '%s'\n", subj, msg)
+        printMsg(resp, 1)
+        nc.Close()
+      },
+    },
     {
       Name:       "pub",
       ShortName:  "p",


### PR DESCRIPTION
```
NAME:
   nats req - Usage: nats req [-s server url] [--ssl] [-t] [-w] <subject> <msg> 


USAGE:
   nats req [command options] [arguments...]

OPTIONS:
   -s "nats://localhost:4222"   The nats server URLs (separated by comma).
                Server Url must be in following format: nats://nats_user:nats_password@host:port or nats://host:port
   --ssl            Use Secure Connection
   -w "2s"          Duration to wait for response, eg '1s'
   -t               Display timestamps
   -r               Display raw output
```
